### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/vi17250/valinta/releases/tag/v0.1.0) - 2025-12-11
+
+### Added
+
+- 🎸 expose ValintaError
+
+### Fixed
+
+- 🐛 it works with all terminal width
+- 🐛 scroll through the list if it's longer that the number of items to render
+- 🐛 current line is highlighted
+- 🐛 navigate through regardless of the terminal width
+- 🐛 uses Clone instead of Copy
+- 🐛 Option has 3 properties
+- 🐛 clear terminal
+- 🐛 restore multilines
+- 🐛 disable line wrapping
+- 🐛 expose only multi_select
+
+### Other
+
+- 🎡 Add release PR and push to crates.io
+- ✏️ add emojies to README
+- Update gif demo
+- 🤖 disable doc test
+- ✏️  document front page and ValintaError and update README
+- ✏️ change header
+- [**breaking**] 💡 follow `valinta-ts` structure 🪅
+- ✏️ front page documentation
+- 💡 `things` are now `items` and that is better
+- 💡 only required modules are exposed and flattened
+- Revert "fix: 🐛 clear terminal"
+- ✏️ Header
+- Include demo image in README
+- ✏️ Update title
+- header formatting in README.md
+- 💡 module organisation
+- 🎡 build + test + clippy on pr and push ([#6](https://github.com/vi17250/valinta/pull/6))
+- 🤖 initial


### PR DESCRIPTION



## 🤖 New release

* `valinta`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/vi17250/valinta/releases/tag/v0.1.0) - 2025-12-11

### Added

- 🎸 expose ValintaError

### Fixed

- 🐛 it works with all terminal width
- 🐛 scroll through the list if it's longer that the number of items to render
- 🐛 current line is highlighted
- 🐛 navigate through regardless of the terminal width
- 🐛 uses Clone instead of Copy
- 🐛 Option has 3 properties
- 🐛 clear terminal
- 🐛 restore multilines
- 🐛 disable line wrapping
- 🐛 expose only multi_select

### Other

- 🎡 Add release PR and push to crates.io
- ✏️ add emojies to README
- Update gif demo
- 🤖 disable doc test
- ✏️  document front page and ValintaError and update README
- ✏️ change header
- [**breaking**] 💡 follow `valinta-ts` structure 🪅
- ✏️ front page documentation
- 💡 `things` are now `items` and that is better
- 💡 only required modules are exposed and flattened
- Revert "fix: 🐛 clear terminal"
- ✏️ Header
- Include demo image in README
- ✏️ Update title
- header formatting in README.md
- 💡 module organisation
- 🎡 build + test + clippy on pr and push ([#6](https://github.com/vi17250/valinta/pull/6))
- 🤖 initial
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).