### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/vi17250/valinta/compare/v0.1.0...v0.1.1) - 2025-12-11
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/vi17250/valinta/releases/tag/v0.1.0) - 2025-12-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "valinta"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valinta"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Victor Aubinaud"]
 description = "Valinta a zero config Rust crate 🦀 for multiple selection in the terminal"


### PR DESCRIPTION



## 🤖 New release

* `valinta`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/vi17250/valinta/compare/v0.1.0...v0.1.1) - 2025-12-11

### Other

- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).